### PR TITLE
Update PyOpenSci links to guidebook

### DIFF
--- a/.github/ISSUE_TEMPLATE/help-request.md
+++ b/.github/ISSUE_TEMPLATE/help-request.md
@@ -26,7 +26,7 @@ Repository Link (if existing):
 
 ```
 
-- Please indicate which [category or categories][PackageCatagories] this package falls under:
+- Please indicate which [category or categories][PackageCategories] this package falls under:
 	- [ ] Data retrieval
 	- [ ] Data extraction
 	- [ ] Data munging
@@ -59,6 +59,6 @@ Repository Link (if existing):
 
 [PackagingGuide]: https://www.pyopensci.org/contributing-guide/authoring/index.html#packaging-guide
 
-[PackageCatagories]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html?highlight=data#package-categories
+[PackageCategories]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html?highlight=data#package-categories
 
 [Comments]: https://github.com/pyOpenSci/governance/issues/8

--- a/.github/ISSUE_TEMPLATE/help-request.md
+++ b/.github/ISSUE_TEMPLATE/help-request.md
@@ -9,9 +9,9 @@ assignees: ''
 
 ## What is this?
 
-To make the review process easier and to help you maintain your package, pyOpenSci requires testing, continuous integration, and full documentation for packages submitted for review (read more [here](https://www.pyopensci.org/dev_guide/packaging/packaging_guide.html#overview). We want to make this as easy as possible for newcomers, so if you'd like some help in prepping your package you can submit this request and we'll assign someone to help you out!
+To make the review process easier and to help you maintain your package, pyOpenSci requires testing, continuous integration, and full documentation for packages submitted for review (read more [here][PackagingGuide]. We want to make this as easy as possible for newcomers, so if you'd like some help in prepping your package you can submit this request and we'll assign someone to help you out!
 
-Before submitting a request, check out our [Packaging Guide](https://www.pyopensci.org/dev_guide/packaging/packaging_guide.html). The answers to your questions might be there already.
+Before submitting a request, check out our [Packaging Guide][PackagingGuide]. The answers to your questions might be there already.
 
 
 ## Package Info
@@ -26,7 +26,7 @@ Repository Link (if existing):
 
 ```
 
-- Please indicate which [category or categories](https://pyopensci.github.io/dev_guide/peer_review/peer_review_proc.html#aims-and-scope) this package falls under:
+- Please indicate which [category or categories][PackageCatagories] this package falls under:
 	- [ ] Data retrieval
 	- [ ] Data extraction
 	- [ ] Data munging
@@ -54,5 +54,11 @@ Repository Link (if existing):
 - Any other questions or issues we should be aware of?:
 
 
+**P.S.** *Have feedback/comments about our review process? Leave a comment [here][Comments]
 
-**P.S.** *Have feedback/comments about our review process? Leave a comment [here](https://github.com/pyOpenSci/governance/issues/8)*
+
+[PackagingGuide]: https://www.pyopensci.org/contributing-guide/authoring/index.html#packaging-guide
+
+[PackageCatagories]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html?highlight=data#package-categories
+
+[Comments]: https://github.com/pyOpenSci/governance/issues/8

--- a/.github/ISSUE_TEMPLATE/presubmission-inquiry.md
+++ b/.github/ISSUE_TEMPLATE/presubmission-inquiry.md
@@ -20,7 +20,7 @@ Repository Link (if existing):
 
 ## Scope 
 
-- Please indicate which [category or categories][PackageCatagories] this package falls under:
+- Please indicate which [category or categories][PackageCategories] this package falls under:
 	- [ ] Data retrieval
 	- [ ] Data extraction
 	- [ ] Data munging
@@ -44,6 +44,6 @@ Repository Link (if existing):
 **P.S.** *Have feedback/comments about our review process? Leave a comment [here][Comments]
 
 
-[PackageCatagories]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html?highlight=data#package-categories
+[PackageCategories]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html?highlight=data#package-categories
 
 [Comments]: https://github.com/pyOpenSci/governance/issues/8

--- a/.github/ISSUE_TEMPLATE/presubmission-inquiry.md
+++ b/.github/ISSUE_TEMPLATE/presubmission-inquiry.md
@@ -20,7 +20,7 @@ Repository Link (if existing):
 
 ## Scope 
 
-- Please indicate which [category or categories](https://pyopensci.github.io/dev_guide/peer_review/peer_review_proc.html#aims-and-scope) this package falls under:
+- Please indicate which [category or categories][PackageCatagories] this package falls under:
 	- [ ] Data retrieval
 	- [ ] Data extraction
 	- [ ] Data munging
@@ -41,4 +41,9 @@ Repository Link (if existing):
 
 
 
-**P.S.** *Have feedback/comments about our review process? Leave a comment [here](https://github.com/pyOpenSci/governance/issues/8)*
+**P.S.** *Have feedback/comments about our review process? Leave a comment [here][Comments]
+
+
+[PackageCatagories]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html?highlight=data#package-categories
+
+[Comments]: https://github.com/pyOpenSci/governance/issues/8

--- a/.github/ISSUE_TEMPLATE/submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review.md
@@ -104,8 +104,6 @@ This option will allow reviewers to open smaller issues that can then be linked 
 
 [PyOpenSciCodeOfConduct]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/code-of-conduct.html?highlight=code%20conduct
 
-[GovernanceIssues]: https://github.com/pyOpenSci/governance/issues/8
-
 [OsiApprovedLicense]: https://opensource.org/licenses
 
 [Templates]: https://www.pyopensci.org/contributing-guide/appendices/templates.html

--- a/.github/ISSUE_TEMPLATE/submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review.md
@@ -25,7 +25,7 @@ Version accepted: TBD
 - Include a brief paragraph describing what your package does:
 
 ## Scope 
-- Please indicate which [category or categories](https://www.pyopensci.org/dev_guide/peer_review/aims_scope.html) this package falls under:
+- Please indicate which [category or categories][PackageCatagories] this package falls under:
 	- [ ] Data retrieval
 	- [ ] Data extraction
 	- [ ] Data munging
@@ -35,7 +35,7 @@ Version accepted: TBD
 	- [ ] Education
 	- [ ] Data visualization*
 
-\* Please fill out a pre-submission inquiry before submitting a data visualization package. For more info, see [this section](https://www.pyopensci.org/dev_guide/peer_review/aims_scope.html#notes-on-categories) of our guidebook.
+\* Please fill out a pre-submission inquiry before submitting a data visualization package. For more info, see [notes on categories][NotesOnCategories] of our guidebook.
 
 - Explain how the and why the package falls under these categories (briefly, 1-2 sentences):
 
@@ -47,10 +47,10 @@ Version accepted: TBD
 
 ## Technical checks
 
-For details about the pyOpenSci packaging requirements, see our [packaging guide](https://www.pyopensci.org/dev_guide/packaging/packaging_guide.html). Confirm each of the following by checking the box.  This package:
+For details about the pyOpenSci packaging requirements, see our [packaging guide][PackagingGuide]. Confirm each of the following by checking the box.  This package:
 
 - [ ] does not violate the Terms of Service of any service it interacts with. 
-- [ ] has an [OSI approved license](https://opensource.org/licenses)
+- [ ] has an [OSI approved license][OsiApprovedLicense].
 - [ ] contains a README with instructions for installing the development version. 
 - [ ] includes documentation with examples for all functions.
 - [ ] contains a vignette with examples of its essential functions and uses.
@@ -59,14 +59,14 @@ For details about the pyOpenSci packaging requirements, see our [packaging guide
 
 ## Publication options
 
-- [ ] Do you wish to automatically submit to the [Journal of Open Source Software](http://joss.theoj.org/)? If so:
+- [ ] Do you wish to automatically submit to the [Journal of Open Source Software][JournalOfOpenSourceSoftware]? If so:
 
 <details>
  <summary>JOSS Checks</summary>  
 
-- [ ] The package has an **obvious research application** according to JOSS's definition in their [submission requirements](https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements). Be aware that completing the pyOpenSci review process **does not** guarantee acceptance to JOSS. Be sure to read their submission requirements (linked above) if you are interested in submitting to JOSS. 
-- [ ] The package is not a "minor utility" as defined by JOSS's [submission requirements](https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements): "Minor ‘utility’ packages, including ‘thin’ API clients, are not acceptable." pyOpenSci welcomes these packages under "Data Retrieval", but JOSS has slightly different criteria.
-- [ ] The package contains a `paper.md` matching [JOSS's requirements](https://joss.readthedocs.io/en/latest/submitting.html#what-should-my-paper-contain) with a high-level description in the package root or in `inst/`.
+- [ ] The package has an **obvious research application** according to JOSS's definition in their [submission requirements][JossSubmissionRequirements]. Be aware that completing the pyOpenSci review process **does not** guarantee acceptance to JOSS. Be sure to read their submission requirements (linked above) if you are interested in submitting to JOSS.
+- [ ] The package is not a "minor utility" as defined by JOSS's [submission requirements][JossSubmissionRequirements]: "Minor ‘utility’ packages, including ‘thin’ API clients, are not acceptable." pyOpenSci welcomes these packages under "Data Retrieval", but JOSS has slightly different criteria.
+- [ ] The package contains a `paper.md` matching [JOSS's requirements][JossPaperRequirements] with a high-level description in the package root or in `inst/`.
 - [ ] The package is deposited in a long-term repository with the DOI: 
 
 *Note: Do not submit your package separately to JOSS*
@@ -80,11 +80,34 @@ This option will allow reviewers to open smaller issues that can then be linked 
 
 ## Code of conduct
 
-- [ ] I agree to abide by [pyOpenSci's Code of Conduct](https://www.pyopensci.org/contributing-guide/peer_review/coc.html) during the review process and in maintaining my package should it be accepted.
+- [ ] I agree to abide by [pyOpenSci's Code of Conduct][PyOpenSciCodeOfConduct] during the review process and in maintaining my package should it be accepted.
 
 
-**P.S.** *Have feedback/comments about our review process? Leave a comment [here](https://github.com/pyOpenSci/governance/issues/8)*
+**P.S.** *Have feedback/comments about our review process? Leave a comment [here][Comments]
 
 ## Editor and Review Templates
 
-[Editor and review templates can be found here](https://www.pyopensci.org/contributing-guide/appendices/templates.html)
+[Editor and review templates can be found here][Templates]
+
+[PackagingGuide]: https://www.pyopensci.org/contributing-guide/authoring/index.html#packaging-guide
+
+[PackageCatagories]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html?highlight=data#package-categories
+
+[NotesOnCategories]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html?highlight=data#notes-on-categories
+
+
+[JournalOfOpenSourceSoftware]: http://joss.theoj.org/
+
+[JossSubmissionRequirements]: https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements
+
+[JossPaperRequirements]: https://joss.readthedocs.io/en/latest/submitting.html#what-should-my-paper-contain
+
+[PyOpenSciCodeOfConduct]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/code-of-conduct.html?highlight=code%20conduct
+
+[GovernanceIssues]: https://github.com/pyOpenSci/governance/issues/8
+
+[OsiApprovedLicense]: https://opensource.org/licenses
+
+[Templates]: https://www.pyopensci.org/contributing-guide/appendices/templates.html
+
+[Comments]: https://github.com/pyOpenSci/governance/issues/8

--- a/.github/ISSUE_TEMPLATE/submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review.md
@@ -25,7 +25,7 @@ Version accepted: TBD
 - Include a brief paragraph describing what your package does:
 
 ## Scope 
-- Please indicate which [category or categories][PackageCatagories] this package falls under:
+- Please indicate which [category or categories][PackageCategories] this package falls under:
 	- [ ] Data retrieval
 	- [ ] Data extraction
 	- [ ] Data munging
@@ -91,7 +91,7 @@ This option will allow reviewers to open smaller issues that can then be linked 
 
 [PackagingGuide]: https://www.pyopensci.org/contributing-guide/authoring/index.html#packaging-guide
 
-[PackageCatagories]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html?highlight=data#package-categories
+[PackageCategories]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html?highlight=data#package-categories
 
 [NotesOnCategories]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html?highlight=data#notes-on-categories
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,28 @@
 # pyOpenSci Software Peer Review
 
-This repo hosts the pyOpenSci review process. Packages contributed to pyOpenSci undergo an open peer-review by community reviewers. 
+This repo hosts the pyOpenSci review process. Packages contributed to pyOpenSci undergo an open peer-review by community reviewers.
 
-If you are interested in submitting a package, check out our [guidebook](https://www.pyopensci.org/dev_guide/intro.html) for info about how to package your code and submit a request for review. For authors, the most important sections are the [scope of pyOpenSci](https://www.pyopensci.org/dev_guide/peer_review/aims_scope.html), the [author guide](https://www.pyopensci.org/dev_guide/peer_review/author_guide.html), and the [packaging guide](https://www.pyopensci.org/dev_guide/packaging/packaging_guide.html). For details about the exact timeline and process of peer-review, see [this section](https://www.pyopensci.org/dev_guide/peer_review/peer_review_proc.html).
+If you are interested in submitting a package, check out our [guidebook][Guidebook] for info about how to package your code and submit a request for review. For authors, the most important sections are the [scope of pyOpenSci][Scope], the [author guide][AuthorGuide], and the [
+packaging guide][PackagingGuide]. For details about the exact timeline and process of peer-review, see [peer review timeline][PeerReviewTimeline].
 
-When you are ready to submit for review, fill out the [Submission template](https://github.com/pyOpenSci/software-review/issues/new?assignees=&labels=&template=submit-software-for-review.md&title=). 
+When you are ready to submit for review, fill out the [Submission template][SubmissionTemplate]
+.
 
-If your package is not yet fully-developed or you're not sure whether it fits within pyOpenSci's [scope](https://www.pyopensci.org/dev_guide/peer_review/aims_scope.html), you can create a [presubmission inquiry issue](https://github.com/pyOpenSci/software-review/issues/new?assignees=&labels=&template=presubmission-inquiry.md&title=).
+If your package is not yet fully-developed or you're not sure whether it fits within pyOpenSci's [
+scope][Scope], you can create a [presubmission inquiry issue][PresubmissionInquiryIssue].
+
+[Guidebook]: https://www.pyopensci.org/contributing-guide/intro.html
+
+[Scope]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html
+
+[AuthorGuide]: https://www.pyopensci.org/contributing-guide/authoring/index.html
+
+[PackagingGuide]: https://www.pyopensci.org/contributing-guide/authoring/index.html#packaging-guide
+
+[PeerReviewTimeline]: https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/intro.html#the-peer-review-timeline
+
+[SubmissionTemplate]: https://github.com/pyOpenSci/software-review/issues/new?assignees=&labels=&template=submit-software-for-review.md&title=
+
+[PresubmissionInquiryIssue]: https://github.com/pyOpenSci/software-review/issues/new?assignees=&labels=&template=presubmission-inquiry.md&title=
 
 


### PR DESCRIPTION
#### Description:
- Fix current 404 errors for guidebook links
- Update PyOpenSci links to guidebook to live links
- Configure links as references


#### Testing Notes:
- Manually clicked on each of the updated links and verified they go to a live url.
- Note: for some of the PyOpenSci links I made a best guess at correct link.  So it would be good for someone to review and let me know if any corrections are needed.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC