### PR TITLE
Removing we are on pause from the submission template

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review.md
@@ -1,8 +1,6 @@
-## pyOpenSci Software Submission 
-
 ---
 name: Submit Software for Review
-about: Use to submit your Python package for peer review
+about: Use to submit your Python package for pyOpenSci peer review
 title: ''
 labels: 1/editor-checks, New Submission!
 assignees: ''
@@ -10,7 +8,7 @@ assignees: ''
 ---
 
 Submitting Author: Name (@github_handle)
-List of all maintainers: (@github_handle1, @github_handle2)
+All current maintainers: (@github_handle1, @github_handle2)
 Package Name: Package name here
 One-Line Description of Package: Description here 
 Repository Link:  

--- a/.github/ISSUE_TEMPLATE/submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/submit-software-for-review.md
@@ -1,10 +1,4 @@
-## pyOpenSci is on pause while we get setup at a new home
-
-*IMPORTANT NOTE:* Hi there Python open source colleague! This is a friendly note that pyOpenSci is currently 
-on pause while we move to a new home. We will be back, up and running in the fall (likely 
-September) 2022! We suggest that you hold off submitting your package until we are back in 
-operations in September 2022. If you have questions, please reach out to us using 
-the [discussions section of this repository](https://github.com/pyOpenSci/software-review/discussions). 
+## pyOpenSci Software Submission 
 
 ---
 name: Submit Software for Review
@@ -15,17 +9,19 @@ assignees: ''
 
 ---
 
-Submitting Author: Name (@github_handle)  
-Package Name: 
-One-Line Description of Package: 
+Submitting Author: Name (@github_handle)
+List of all maintainers: (@github_handle1, @github_handle2)
+Package Name: Package name here
+One-Line Description of Package: Description here 
 Repository Link:  
 Version submitted:   
 Editor: TBD  
 Reviewer 1: TBD  
 Reviewer 2: TBD  
 Archive: TBD  
-Version accepted: TBD   
+Version accepted: TBD 
 Date accepted (month/day/year): TBD
+
 ---
 
 ## Description


### PR DESCRIPTION
This PR does a few things

1. it remove the "we are on pause" language so we can begin accepting submissions again
2. It adds a date accepted to the yaml to allow us to better track acceptance of packages. this will be useful for database purpose and website publishing
3. requests a list of all maintainers of the package. i realized most packages have more than 1 and having all of them in our database is useful for many reasons. also we would invite them all to slack and promote them all on twitter. 

NOTE: there is a quirk where the markdown isn't rendering the way that we want it to as a list without bullets but the template itself is fine - i've checked it in several text editors. 

in the FUTURE could be worth considering a better template like this: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository but that might be at the risk of losing parsability like what ROS uses